### PR TITLE
Fix package issue safe-area-context

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -31,7 +31,7 @@
         "react-native-placesearch": "^4.0.1",
         "react-native-popup-confirm-toast": "^2.2.7",
         "react-native-reanimated": "^2.14.1",
-        "react-native-safe-area-context": "^4.4.1",
+        "react-native-safe-area-context": "^3.1.9",
         "react-native-screens": "^3.18.2",
         "react-native-sound": "^0.11.2",
         "react-native-sound-player": "^0.10.3",
@@ -13531,9 +13531,9 @@
       }
     },
     "node_modules/react-native-safe-area-context": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-4.4.1.tgz",
-      "integrity": "sha512-N9XTjiuD73ZpVlejHrUWIFZc+6Z14co1K/p1IFMkImU7+avD69F3y+lhkqA2hN/+vljdZrBSiOwXPkuo43nFQA==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-3.1.9.tgz",
+      "integrity": "sha512-wmcGbdyE/vBSL5IjDPReoJUEqxkZsywZw5gPwsVUV1NBpw5eTIdnL6Y0uNKHE25Z661moxPHQz6kwAkYQyorxA==",
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
@@ -26640,9 +26640,9 @@
       }
     },
     "react-native-safe-area-context": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-4.4.1.tgz",
-      "integrity": "sha512-N9XTjiuD73ZpVlejHrUWIFZc+6Z14co1K/p1IFMkImU7+avD69F3y+lhkqA2hN/+vljdZrBSiOwXPkuo43nFQA==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-3.1.9.tgz",
+      "integrity": "sha512-wmcGbdyE/vBSL5IjDPReoJUEqxkZsywZw5gPwsVUV1NBpw5eTIdnL6Y0uNKHE25Z661moxPHQz6kwAkYQyorxA==",
       "requires": {}
     },
     "react-native-screens": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,7 +32,7 @@
     "react-native-placesearch": "^4.0.1",
     "react-native-popup-confirm-toast": "^2.2.7",
     "react-native-reanimated": "^2.14.1",
-    "react-native-safe-area-context": "^4.4.1",
+    "react-native-safe-area-context": "^3.1.9",
     "react-native-screens": "^3.18.2",
     "react-native-sound": "^0.11.2",
     "react-native-sound-player": "^0.10.3",


### PR DESCRIPTION
### Summary
Fixed issue with `react-native-safe-area-context` 


### Details
When new packages had to be installed this package would be an issue and wouldn't allow it to go through. I downloaded it as version 3.1.9 and it seems to have fixed the issues where we would have to uninstall it and reinstall it to get new packages installed. 
