### PR TITLE
hotfix 2: use creatorId instead.

### DIFF
--- a/backend/routes/user.js
+++ b/backend/routes/user.js
@@ -15,7 +15,8 @@ router.use((err, req, res, next) => {
 
 router.get("/username", async (req, res) => {
     try {
-        const username = await UserManager.getUsernameById(req.session.user._id);
+        const creatorId = req.query.creatorId;
+        const username = await UserManager.getUsernameById(creatorId);
         res.send({
             statusCode: 200,
             username: username,

--- a/backend/routes/user.js
+++ b/backend/routes/user.js
@@ -15,8 +15,8 @@ router.use((err, req, res, next) => {
 
 router.get("/username", async (req, res) => {
     try {
-        const creatorId = req.query.creatorId;
-        const username = await UserManager.getUsernameById(creatorId);
+        const id = req.query.id;
+        const username = await UserManager.getUsernameById(id);
         res.send({
             statusCode: 200,
             username: username,


### PR DESCRIPTION
### Summary
Modify the endpoint to get the username of the creator instead of the currently logged in user.
