### PR TITLE
allow cors without specifying client origin

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -25,13 +25,7 @@ app.use(bodyParser.urlencoded({
     extended: true
 }));
 
-app.use(
-    cors({
-      origin: CLIENT_URL,
-      methods: "GET,HEAD,PUT,PATCH,POST,DELETE",
-      credentials: true,
-    })
-  );
+app.use(cors());
 
 app.use(session({
     secret: "535510n53cr3t",


### PR DESCRIPTION
### Summary
the change is to allow cors from browser without spawning a localhost process. this is mainly for the admin dashboard, so we can just open the html page on the browser and access the localhost server